### PR TITLE
API page TOC links are broken.

### DIFF
--- a/api.md
+++ b/api.md
@@ -5,14 +5,14 @@ title: API
 
 # General API
 
-- [Hammer](#toc_1)
-- [Hammer.defaults](#toc_3)
-- [Hammer.Manager](#toc_9)
-- [Hammer.Recognizer](#toc_16)
-- [Hammer.input event](#toc_21)
-- [Event object](#toc_22)
-- [Constants](#toc_23)
-- [Utils](#toc_27)
+- [Hammer](#hammer)
+- [Hammer.defaults](#hammerdefaults)
+- [Hammer.Manager](#hammermanager)
+- [Hammer.Recognizer](#hammerrecognizer)
+- [Hammer.input event](#hammerinput-event)
+- [Event object](#event-object)
+- [Constants](#constants)
+- [Utils](#utils)
 
 ## Hammer
 Creates a Manager instance with a default set of recognizers and returns the manager instance. The default set


### PR DESCRIPTION
Looks like the IDs for the separate sections changed somewhere.
