### PR TITLE
Update recognizer-press.md

### DIFF
--- a/recognizer-press.md
+++ b/recognizer-press.md
@@ -10,7 +10,7 @@ Recognized when the pointer is down for x ms without any movement.
 |-----------|----------|-------------------|
 | event     | press    | Name of the event. |
 | pointers  | 1        | Required pointers. |
-| threshold | 5        | Minimal movement that is allowed while pressing. |
+| threshold | 5        | Maximum movement that is allowed while pressing. |
 | time      | 500      | Minimal press time in ms. |
 
 ## Events


### PR DESCRIPTION
Press requires that there be no movement. The description for the threshold parameter has typo "minimal", which should instead be "maximum".

(By the way, I think it may be slightly more appropriate to use "minimum" instead of "minimal" in the other description fields, but it's not a big deal.)