### PR TITLE
Update swipe recognizer with new default velocity

### DIFF
--- a/recognizer-swipe.md
+++ b/recognizer-swipe.md
@@ -12,7 +12,7 @@ Recognized when the pointer is moving fast (velocity), with enough distance in t
 | pointers  | 1        | Required pointers. |
 | threshold | 10       | Minimal distance required before recognizing. |
 | direction | DIRECTION_ALL | Direction of the panning. |
-| velocity  | 0.65     | Minimal velocity required before recognizing, unit is in px per ms. |
+| velocity  | 0.3      | Minimal velocity required before recognizing, unit is in px per ms. |
 
 ## Events
 - swipe, together with all of below


### PR DESCRIPTION
The minimum velocity seems to have been changed from 0.65 to 0.3: https://github.com/hammerjs/hammer.js/blob/master/src/recognizers/swipe.js#L19