### PR TITLE
Updated press defaults in docs

### DIFF
--- a/recognizer-press.md
+++ b/recognizer-press.md
@@ -10,8 +10,8 @@ Recognized when the pointer is down for x ms without any movement.
 |-----------|----------|-------------------|
 | event     | press    | Name of the event. |
 | pointers  | 1        | Required pointers. |
-| threshold | 5        | Minimal movement that is allowed while pressing. |
-| time      | 500      | Minimal press time in ms. |
+| threshold | 9        | Minimal movement that is allowed while pressing. |
+| time      | 251      | Minimal press time in ms. |
 
 ## Events
 - press


### PR DESCRIPTION
Looks like default threshold and press time were updated in October:
https://github.com/hammerjs/hammer.js/blob/master/src/recognizers/press.js

Updated docs to match.