### PR TITLE
Fix broken links in jumpnav.

### DIFF
--- a/api.md
+++ b/api.md
@@ -6,10 +6,10 @@ title: API
 # General API
 
 - [Hammer](#hammer)
-- [Hammer.defaults](#hammer.defaults)
-- [Hammer.Manager](#hammer.manager)
-- [Hammer.Recognizer](#hammer.recognizer)
-- [Hammer.input event](#hammer.input-event)
+- [Hammer.defaults](#hammer-defaults)
+- [Hammer.Manager](#hammer-manager)
+- [Hammer.Recognizer](#hammer-recognizer)
+- [Hammer.input event](#hammer-input-event)
 - [Event object](#event-object)
 - [Constants](#constants)
 - [Utils](#utils)


### PR DESCRIPTION
Issue:
The IDs on the api-page convert the `.` to `-`, which means a couple of the the navigation links are broken. For example, see how these links don't jump down the page:
- [http://hammerjs.github.io/api/#hammer.defaults](http://hammerjs.github.io/api/#hammer.defaults)
- [http://hammerjs.github.io/api/#hammer.manager](http://hammerjs.github.io/api/#hammer.manager)
- [http://hammerjs.github.io/api/#hammer.recognizer](http://hammerjs.github.io/api/#hammer.recognizer)
- [http://hammerjs.github.io/api/#hammer.input-event](http://hammerjs.github.io/api/#hammer.input-event)
