### PR TITLE
Update defaults for pan recogniser docs

### DIFF
--- a/recognizer-pan.md
+++ b/recognizer-pan.md
@@ -11,7 +11,7 @@ Recognized when the pointer is down and moved in the allowed direction.
 | event     | pan      | Name of the event. |
 | pointers  | 1        | Required pointers. 0 for all pointers. |
 | threshold | 10       | Minimal pan distance required before recognizing. |
-| direction | DIRECTION_ALL | Direction of the panning. |
+| direction | DIRECTION_HORIZONTAL | Direction of the panning. |
 
 ## Events
 - pan, together with all of below


### PR DESCRIPTION
As described here - https://github.com/hammerjs/hammer.js/issues/1003 - the default is DIRECTION_HORIZONTAL for good reason
