### PR TITLE
docs: Update fonts to be loaded over SSL

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -10,5 +10,5 @@
 
     <link rel="icon" href="{{"/assets/img/favicon.ico"|prepend:site.baseurl}}">
     <link rel="stylesheet" href="{{"/assets/css/index.css"|prepend:site.baseurl}}">
-    <link rel="stylesheet" href="http://fonts.googleapis.com/css?family=Open+Sans:400,700,800,600">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:400,700,800,600">
 </head>


### PR DESCRIPTION
Otherwise, Google Chrome on Mac looks like:
![image](https://cloud.githubusercontent.com/assets/2925395/21753732/a33aa880-d5b8-11e6-8224-ef7e0b342a33.png)

Then, after enabling:

![image](https://cloud.githubusercontent.com/assets/2925395/21753726/90be3f0a-d5b8-11e6-8d56-99fbdb6f499d.png)
