### PR TITLE
Fix API’s broken navigation links

### DIFF
--- a/api.md
+++ b/api.md
@@ -6,10 +6,10 @@ title: API
 # General API
 
 - [Hammer](#hammer)
-- [Hammer.defaults](#hammer.defaults)
-- [Hammer.Manager](#hammer.manager)
-- [Hammer.Recognizer](#hammer.recognizer)
-- [Hammer.input event](#hammer.input-event)
+- [Hammer.defaults](#hammerdefaults)
+- [Hammer.Manager](#hammermanager)
+- [Hammer.Recognizer](#hammerrecognizer)
+- [Hammer.input event](#hammerinput-event)
 - [Event object](#event-object)
 - [Constants](#constants)
 - [Utils](#utils)


### PR DESCRIPTION
Looks like the generated HTML doesn’t like to output dots in `id` attributes.