### PR TITLE
Fix rotation bug on home page

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -177,7 +177,7 @@
 	var initAngle = 0;
 	function onRotate(ev) {
 	    if(ev.type == 'rotatestart') {
-	        initAngle = transform.angle || 0;
+	        initAngle = (transform.angle || 0) - ev.rotation;
 	    }
 
 	    el.className = '';


### PR DESCRIPTION
Steps to reproduce this bug:
1. Take mobile phone and open this example https://cdn.rawgit.com/hammerjs/hammer.js/master/tests/manual/visual.html
2. Put two fingers over each other vertically, rotation will have wrong initial angle.

In this PR this bug is fixed.
Here related bug in documentation: https://github.com/hammerjs/hammer.js/pull/1215