### PR TITLE
fix broken header links on API page

### DIFF
--- a/api.md
+++ b/api.md
@@ -6,10 +6,10 @@ title: API
 # General API
 
 - [Hammer](#hammer)
-- [Hammer.defaults](#hammer-defaults)
-- [Hammer.Manager](#hammer-manager)
-- [Hammer.Recognizer](#hammer-recognizer)
-- [Hammer.input event](#hammer-input-event)
+- [Hammer.defaults](#hammerdefaults)
+- [Hammer.Manager](#hammermanager)
+- [Hammer.Recognizer](#hammerrecognizer)
+- [Hammer.input event](#hammerinput-event)
 - [Event object](#event-object)
 - [Constants](#constants)
 - [Utils](#utils)


### PR DESCRIPTION
github markdown has been changed so that periods are simply removed instead of being change to a dash for header links/anchors.